### PR TITLE
Added albumCoverUrl field in SpotifySearchMapper and Track.ts

### DIFF
--- a/src/Shared/Models/Track.ts
+++ b/src/Shared/Models/Track.ts
@@ -9,4 +9,5 @@ export interface Track {
     album: SpotifyAlbumDTO
     preview_url: string | null
     artist: SpotifyArtistDTO[];
+    albumImageUrl: string | null
 }

--- a/src/components/Calender/CalenderItem.vue
+++ b/src/components/Calender/CalenderItem.vue
@@ -3,7 +3,7 @@
     <div class="calender-item card clickable" @click="goToEntry">
         <p class="days-on-calendar">{{ currentDay }}</p>   
         <div v-if="entry != undefined"> 
-            <img :src="entry?.track?.album?.images[0]?.url || fallbackImg" :alt="`Calendar Picture for day ${currentDay}`"/>
+            <img :src="entry?.track?.albumImageUrl || fallbackImg"/>
         </div>
     </div>
 </template>

--- a/src/components/SpotifySearch/Mappers/SpotifySearchMapper.ts
+++ b/src/components/SpotifySearch/Mappers/SpotifySearchMapper.ts
@@ -12,7 +12,8 @@ export class SpotifySearchMapper {
                 id: spotifyTrackDTO.id,
                 album: spotifyTrackDTO.album,
                 preview_url: spotifyTrackDTO.preview_url,
-                artist: spotifyTrackDTO.artists
+                artist: spotifyTrackDTO.artists,
+                albumImageUrl: spotifyTrackDTO.album.images[0]?.url
             } as Track);
         });
 


### PR DESCRIPTION
Album cover should be saved even after user logs out now.