### PR TITLE
Refresh cached user state on init

### DIFF
--- a/src/Shared/Clients/UserStateRefreshClient.ts
+++ b/src/Shared/Clients/UserStateRefreshClient.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import type { UserState } from '../Models/UserState';
+import { useUserStateStore } from '../UserStateStore';
+
+export class UserStateRefreshClient {
+    async execute(userId : string) : Promise<UserState> {
+        const userState = useUserStateStore();
+        await userState.checkAccessToken();
+        const token = userState.auth.accessToken;
+
+        const client = axios.create({
+            baseURL: `${import.meta.env.VITE_BACKEND_URL}`,
+            headers: {
+                Authorization: `Bearer ${token}`
+            },
+        });
+
+        const response = await client.get(`/Users/${userId}/refresh`);
+        return response.data;
+    }
+}

--- a/src/Shared/UserStateStore.ts
+++ b/src/Shared/UserStateStore.ts
@@ -3,6 +3,7 @@ import type { UserState } from './Models/UserState';
 import type { Entry } from './Models/Entry';
 import { NewAuthTokenClient } from './Clients/NewAuthTokenClient';
 import { HttpStatusCode } from 'axios';
+import { UserStateRefreshClient } from './Clients/UserStateRefreshClient';
 
 export const useUserStateStore = defineStore('userState', {
     state: (): UserState => {
@@ -73,6 +74,16 @@ export const useUserStateStore = defineStore('userState', {
             if (this.settings?.theme != null) {
                 document.body.className = (`${this.settings.theme}-theme`);
             }
+        },
+        refreshUserState() {
+            const client = new UserStateRefreshClient();
+
+            // Do not await, allow refresh to run in the background asynchronously
+            client.execute( this.id ).then(response => {
+                this.$patch(response);
+            }).catch(error => {
+                console.log(error);
+            });
         }
     }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import SpotifyCallback from '@/components/SpotifyUserLogin/SpotifyCallback.vue';
 import UserProfilePage from '@/components/UserProfilePage/UserProfilePage.vue';
 import { markRaw } from 'vue'
 import AboutUs from './components/AboutUs/AboutUs.vue';
+import { useUserStateStore } from './Shared/UserStateStore';
 
 const routes = [
   { path: '/user/:userId', name: 'User', component: UserProfilePage },
@@ -51,3 +52,9 @@ watch(pinia.state, state => {
 },
 { deep: true}
 );
+
+// If cached login exists, refresh user state in the case that user logged in elsewhere and updated info
+const cache = localStorage.getItem('user_state')
+if(cache != null) {
+  useUserStateStore().refreshUserState();
+}


### PR DESCRIPTION
If user has logged in before, and closes their browser, but theyre information changes (logged in on another computer and made changes or directly altered in mongoDB), refresh cached userState.