### PR TITLE
changed entry date format to relative time

### DIFF
--- a/src/components/EntryItem/EntryItem.vue
+++ b/src/components/EntryItem/EntryItem.vue
@@ -27,7 +27,7 @@
                 Your browser does not support the audio element.
             </audio>
         </div>
-        <p v-text="entry.date.toLocaleString()"></p>
+        <p>{{ dateFormat(entry.date) }}</p>
         </div>
         <!-- Trash button -->
         <button v-if="isOwner" class="btn-delete-entry" @click="confirmation" title="Delete Entry">
@@ -124,6 +124,27 @@ function handleOutsideClick(event: MouseEvent) {
             activeAudioPlayer.value = null;
         }
     }
+}
+
+function dateFormat(date: Date): string {
+  const now = new Date();
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days <= 5) {
+    return `${days}d ago`;
+  } else {
+    // if thime passed is more than 5 days, it will display the full date
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const year = date.getFullYear().toString().slice(-2); 
+    return `${month}/${day}/${year}`;
+  }
 }
 
 onUnmounted(() => {


### PR DESCRIPTION
![Screenshot 2024-11-20 235623](https://github.com/user-attachments/assets/37d7b243-04ae-4c73-a64d-4eb238a5b9a2)
Date format for entries on home page and other users page changes to be relative to the current time (ie. 2m ago, 1d ago, etc). Changes made on EntryItem.vue to change across all users' entry items.